### PR TITLE
add events when fitting and doctrines change

### DIFF
--- a/src/Events/DoctrineUpdated.php
+++ b/src/Events/DoctrineUpdated.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CryptaTech\Seat\Fitting\Events;
+
+use CryptaTech\Seat\Fitting\Models\Doctrine;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DoctrineUpdated
+{
+    use Dispatchable, SerializesModels;
+
+    public Doctrine $doctrine;
+
+    /**
+     * @param Doctrine $doctrine
+     */
+    public function __construct(Doctrine $doctrine)
+    {
+        $this->doctrine = $doctrine;
+    }
+}

--- a/src/Events/FittingUpdated.php
+++ b/src/Events/FittingUpdated.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CryptaTech\Seat\Fitting\Events;
+
+use CryptaTech\Seat\Fitting\Models\Fitting;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FittingUpdated
+{
+    use Dispatchable, SerializesModels;
+
+    public Fitting $fitting;
+
+    /**
+     * @param Fitting $fitting
+     */
+    public function __construct(Fitting $fitting)
+    {
+        $this->fitting = $fitting;
+    }
+}

--- a/src/Http/Controllers/FittingController.php
+++ b/src/Http/Controllers/FittingController.php
@@ -2,6 +2,7 @@
 
 namespace CryptaTech\Seat\Fitting\Http\Controllers;
 
+use CryptaTech\Seat\Fitting\Events\DoctrineUpdated;
 use CryptaTech\Seat\Fitting\Events\FittingUpdated;
 use CryptaTech\Seat\Fitting\Helpers\CalculateConstants;
 use CryptaTech\Seat\Fitting\Helpers\CalculateEft;
@@ -420,6 +421,8 @@ class FittingController extends Controller implements CalculateConstants
         foreach ($request->selectedFits as $fitId) {
             $doctrine->fittings()->sync($request->selectedFits);
         }
+
+        DoctrineUpdated::dispatch($doctrine);
 
         return redirect()->route('cryptafitting::doctrineview');
     }

--- a/src/Http/Controllers/FittingController.php
+++ b/src/Http/Controllers/FittingController.php
@@ -2,6 +2,7 @@
 
 namespace CryptaTech\Seat\Fitting\Http\Controllers;
 
+use CryptaTech\Seat\Fitting\Events\FittingUpdated;
 use CryptaTech\Seat\Fitting\Helpers\CalculateConstants;
 use CryptaTech\Seat\Fitting\Helpers\CalculateEft;
 use CryptaTech\Seat\Fitting\Models\Doctrine;
@@ -289,7 +290,10 @@ class FittingController extends Controller implements CalculateConstants
             $fit = Fitting::createFromEve($request->eftfitting, $request->fitSelection);
         } else {
             $fit = Fitting::createFromEve($request->eftfitting);
-        }        
+        }
+
+        // dispatch an event so other plugins know that a fitting has updated
+        FittingUpdated::dispatch($fit);
 
         $fitlist = $this->getFittingList();
 

--- a/src/Models/Fitting.php
+++ b/src/Models/Fitting.php
@@ -348,6 +348,9 @@ class Fitting extends Model
             }
         }
 
+        // laravel caches relations, meaning that with the way we add items to the fitting, the cache isn't invalidated automatically
+        $fit->unsetRelations();
+
         return $fit;
     }
 }

--- a/src/Models/FittingItem.php
+++ b/src/Models/FittingItem.php
@@ -26,6 +26,7 @@ use CryptaTech\Seat\Fitting\Models\Sde\InvFlag;
 use Illuminate\Database\Eloquent\Model;
 use Seat\Eveapi\Models\Sde\InvType;
 use Seat\Services\Contracts\HasTypeID;
+use Seat\Services\Contracts\HasTypeIDWithAmount;
 use Seat\Services\Contracts\IPriceable;
 
 /**
@@ -33,7 +34,7 @@ use Seat\Services\Contracts\IPriceable;
  *
  * @package CryptaTech\Seat\Fitting\Models
  */
-class FittingItem extends Model implements HasTypeID, IPriceable
+class FittingItem extends Model implements HasTypeID, HasTypeIDWithAmount, IPriceable
 {
     /**
      * @var bool


### PR DESCRIPTION
seat-inventory needs to update some stuff when a fitting changes. I tried to use an observer for this, but: The plugin first saves the fitting and only afterwards save the items of the fit, meaning the observer fires before the items of a fitting have been saved.

This PR adds a laravel event that fires after a fitting has been saved.

The same has been done with doctrines for the same reason.

This PR depends on https://github.com/eveseat/services/pull/180