### PR TITLE
Fix the discord link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # seat-fitting
+
 A module for [SeAT](https://github.com/eveseat/seat) that holds fittings and can compare the required skills for a fit to your character.
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/denngarr/seat-fitting.svg?style=flat-square)]()
 [![License](https://img.shields.io/badge/license-GPLv2-blue.svg?style=flat-square)](https://raw.githubusercontent.com/dysath/seat-srp/master/LICENSE)
 
-If you have issues with this, you can contact me on Eve as **Crypta Electrica**, or on the [https://eveseat.github.io/docs/about/contact/](SeAT Discord)
+If you have issues with this, you can contact me on Eve as **Crypta Electrica**, or on the [SeAT Discord](https://eveseat.github.io/docs/about/contact/)
 
 ## Quick Installation:
 
@@ -33,5 +34,3 @@ Good luck, and Happy Hunting!!  o7
 In order to get an idea of the usage of this plugin, a very simplistic form of anonymous usage tracking has been implemented.
 
 Read more about the system in use [here](https://github.com/Crypta-Eve/snoopy)
-
-


### PR DESCRIPTION
This change just fixes the discord link in the readme (markdown was inverted).