### PR TITLE
Fix null pointer exceptions and add search functionality

### DIFF
--- a/src/Http/Controllers/FittingController.php
+++ b/src/Http/Controllers/FittingController.php
@@ -158,7 +158,7 @@ class FittingController extends Controller implements CalculateConstants
                 $rank = DgmTypeAttribute::where('typeID', $skill->skill_id)->where('attributeID', '275')->first();
 
                 $skillsToons['characters'][$index]['skill'][$skill->skill_id]['level'] = $skill->trained_skill_level;
-                $skillsToons['characters'][$index]['skill'][$skill->skill_id]['rank'] = $rank->valueFloat;
+                $skillsToons['characters'][$index]['skill'][$skill->skill_id]['rank'] = $rank ? $rank->valueFloat : 1;
             }
 
             // Fill in missing skills so Javascript doesn't barf and you have the correct rank
@@ -171,7 +171,7 @@ class FittingController extends Controller implements CalculateConstants
                 $rank = DgmTypeAttribute::where('typeID', $skill['typeId'])->where('attributeID', '275')->first();
 
                 $skillsToons['characters'][$index]['skill'][$skill['typeId']]['level'] = 0;
-                $skillsToons['characters'][$index]['skill'][$skill['typeId']]['rank'] = $rank->valueFloat;
+                $skillsToons['characters'][$index]['skill'][$skill['typeId']]['rank'] = $rank ? $rank->valueFloat : 1;
             }
         }
 
@@ -216,6 +216,17 @@ class FittingController extends Controller implements CalculateConstants
     {
         $fit = Fitting::find($id);
         $provider = setting('cryptatech_seat_fitting_price_provider', true);
+        
+        // Check if price provider is configured
+        if ($provider === null) {
+            return response()->json([
+                'error' => 'Price provider not configured. Please configure it in Fitting Settings.',
+                'total' => 0,
+                'ship' => 0,
+                'volume' => 0
+            ], 400);
+        }
+        
         $items = $fit->fitItems;
         $ship = new FittingItem;
         $ship->type_id = $fit->ship_type_id;


### PR DESCRIPTION
# Fix null pointer exceptions and add search functionality

## Summary
This PR fixes two critical bugs causing 500 errors and adds search functionality to improve usability:
1. Character skills dropdown not appearing due to null pointer exception
2. Price calculation crashes when price provider is not configured
3. Search boxes for filtering fittings by ship type and fit name

---

## Bug #1: Character Skills Dropdown Missing (500 Error)

### Problem
- **Error:** `Attempt to read property 'valueFloat' on null`
- **Location:** `FittingController.php` lines 161 and 174
- **Impact:** Character dropdown (third column) doesn't appear on Fittings page

### Root Cause
The code attempts to retrieve skill rank (difficulty multiplier) data from the SDE database:
```php
$rank = DgmTypeAttribute::where('typeID', $skill->skill_id)
    ->where('attributeID', '275')
    ->first();

$skillsToons['characters'][$index]['skill'][$skill->skill_id]['rank'] = $rank->valueFloat; // CRASH!
```

When the database is missing rank data for a skill (incomplete SDE data), `$rank` is `null`, and accessing `$rank->valueFloat` throws a null pointer exception.

### Solution
Added null checks with a safe default value (rank = 1):
```php
// Line 161:
$skillsToons['characters'][$index]['skill'][$skill->skill_id]['rank'] = $rank ? $rank->valueFloat : 1;

// Line 174:
$skillsToons['characters'][$index]['skill'][$skill['typeId']]['rank'] = $rank ? $rank->valueFloat : 1;
```

**Why rank = 1?** In EVE Online, rank 1 represents the easiest/fastest skills to train. Using 1 as a default ensures conservative training time estimates and prevents UI breakage.

**Note:** Skills at level 0 are valid (injected but not trained) and are correctly preserved by this fix.

---

## Bug #2: Price Provider Error

### Problem
- **Error:** `getPrices(): Argument #1 ($instance_id) must be of type int, null given`
- **Location:** `FittingController.php` line 227
- **Impact:** Crash when clicking to view fitting costs

### Root Cause
The code attempts to calculate fitting prices without checking if a price provider is configured:
```php
$provider = setting('cryptatech_seat_fitting_price_provider', true); // Could be null!

PriceProviderSystem::getPrices($provider, $items); // CRASH if $provider is null!
```

When no price provider is configured (fresh installations or users who don't use pricing), `$provider` is `null`, causing a type error.

### Solution
Added a null check with a user-friendly error response:
```php
$provider = setting('cryptatech_seat_fitting_price_provider', true);

if ($provider === null) {
    return response()->json([
        'error' => 'Price provider not configured. Please configure it in Fitting Settings.',
        'total' => 0,
        'ship' => 0,
        'volume' => 0
    ], 400);
}
```

Instead of crashing, the plugin now returns a helpful error message directing users to configure the price provider.

---

## Enhancement: Search Functionality

### Feature
Added search boxes to the Fittings page for easier navigation of large fitting lists.

### Implementation
- **Ship Type Search:** Filter fittings by ship name (e.g., "Raven", "Zealot")
- **Fit Name Search:** Filter fittings by fitting name (e.g., "PvP", "Fleet")
- **Live Filtering:** Results update as you type
- **Case-insensitive:** Works regardless of capitalization

### Benefits
- Essential for corporations with 50+ fittings
- Instant filtering without page reload
- Clean, intuitive interface
- No additional dependencies required

---

## Files Modified
- `src/Http/Controllers/FittingController.php` - Bug fixes
- `src/resources/views/fitting.blade.php` - Search functionality

<img width="2298" height="1252" alt="seat fitting" src="https://github.com/user-attachments/assets/7a66e54f-e3d0-4b9d-b721-bc7ce790841e" />
